### PR TITLE
Improved bookmarks by using percentages. Sync resumePoints with Trakt.tv

### DIFF
--- a/lib/resources/lib/modules/bookmarks.py
+++ b/lib/resources/lib/modules/bookmarks.py
@@ -1,0 +1,93 @@
+import hashlib
+
+from resources.lib.modules import control
+
+try:
+    from sqlite3 import dbapi2 as database
+except Exception:
+    from pysqlite2 import dbapi2 as database
+
+class Bookmark:
+    def __init__(self, offset):
+        self.offset = offset
+
+def get(name, year='0'):
+
+    try:
+        bookmark = Bookmark(0)
+        if not control.setting('bookmarks') == 'true':
+            raise Exception()
+
+        name = name.replace(" ", "").lower()
+
+        idFile = generate_file_id(name, year)
+        dbcon = database.connect(control.bookmarksFile)
+        dbcur = dbcon.cursor()
+        dbcur.execute("SELECT * FROM bookmark WHERE idFile = '%s'" % idFile)
+        match = dbcur.fetchone()
+
+        offset = float(match[1])
+
+        bookmark.offset = offset
+
+        dbcon.close()
+
+        if bookmark.offset == 0.0:
+            raise Exception()
+
+        minutes, seconds = divmod(float(bookmark.offset), 60)
+        hours, minutes = divmod(minutes, 60)
+        label = '%02d:%02d:%02d' % (hours, minutes, seconds)
+        label = (control.lang(32502) % label).encode('utf-8')
+
+        try:
+            yes = control.dialog.contextmenu([label, control.lang(32501).encode('utf-8'), ])
+        except Exception:
+            yes = control.yesnoDialog(
+                label, '', '', str(name),
+                control.lang(32503).encode('utf-8'),
+                control.lang(32501).encode('utf-8'))
+
+        if yes:
+            bookmark.offset = 0.0
+
+        return bookmark
+    except:
+        return bookmark
+
+
+def insert(name, progressPercentage, year='0'):
+    try:
+        if not control.setting('bookmarks') == 'true':
+            raise Exception()
+
+        ok = int(progressPercentage) >= 2 and progressPercentage <= 92
+        name = name.replace(" ", "").lower()
+        idFile = generate_file_id(name, year)
+
+        control.makeFile(control.dataPath)
+        dbcon = database.connect(control.bookmarksFile)
+        dbcur = dbcon.cursor()
+        dbcur.execute(
+            "CREATE TABLE IF NOT EXISTS bookmark ("
+            "idFile TEXT, "
+            "timeInPercentage TEXT,"
+            "UNIQUE(idFile)"
+            ");")
+        dbcur.execute("DELETE FROM bookmark WHERE idFile = '%s'" % idFile)
+        if ok:
+            dbcur.execute("INSERT INTO bookmark Values (?, ?)", (idFile, progressPercentage))
+        dbcon.commit()
+        dbcon.close()
+    except Exception:
+        pass
+
+def generate_file_id(name, year):
+    idFile = hashlib.md5()
+    for i in name:
+        idFile.update(str(i))
+    for i in year:
+        idFile.update(str(i))
+    idFile = str(idFile.hexdigest())
+
+    return idFile

--- a/lib/resources/lib/modules/trakt.py
+++ b/lib/resources/lib/modules/trakt.py
@@ -31,6 +31,7 @@ from resources.lib.modules import client
 from resources.lib.modules import control
 from resources.lib.modules import log_utils
 from resources.lib.modules import utils
+from resources.lib.modules import bookmarks
 
 BASE_URL = 'https://api.trakt.tv'
 #BASE_URL = 'https://api-v2launch.trakt.tv'
@@ -350,6 +351,26 @@ def syncSeason(imdb):
     except:
         pass
 
+def syncMovieResumePoints():
+    try:
+        if getTraktCredentialsInfo() == False: return
+        last_movie_activities = getTraktAsJson('/sync/playback/movies')
+
+        for activity in last_movie_activities:
+            bookmarks.insert(activity['movie']['title'], activity['progress'], str(activity['movie']['year']))
+    except:
+        pass
+
+def syncEpisodeResumePoints():
+    try:
+        if getTraktCredentialsInfo() == False: return
+        last_episode_activities = getTraktAsJson('/sync/playback/episodes')
+
+        for activity in last_episode_activities:
+            episodeIdentifier = activity['show']['title'] + 'S' + str(activity['episode']['season']) + 'E' + str(activity['episode']['number'])
+            bookmarks.insert(episodeIdentifier, activity['progress'], str(activity['show']['year']))
+    except:
+        pass
 
 def markMovieAsWatched(imdb):
     if not imdb.startswith('tt'): imdb = 'tt' + imdb


### PR DESCRIPTION
Trakt.TV integration in Exodus is great, but I noticed that resume points are not being synced cross-devices. In this PR:

- Moved the bookmarks class to it's own file instead of player.py
- Bookmarks are now saved in percentages instead of time in seconds so we can sync with Trakt. Trakt API return progress in percentage, would be inconvenient to keep using seconds.
- Changed string format for movie/episode name to match what Trakt.tv returns.
- Other improvements.

Sync is started when navigating to "Movies" or "TV Shows". See pull request for plugin.video.exodusredux